### PR TITLE
Update to 8.13, support AGP 9.0+

### DIFF
--- a/core/src/main/kotlin/sh/christian/aaraar/merger/impl/AndroidManifestMerger.kt
+++ b/core/src/main/kotlin/sh/christian/aaraar/merger/impl/AndroidManifestMerger.kt
@@ -20,6 +20,7 @@ class AndroidManifestMerger : Merger<AndroidManifest> {
     )
       .withFeatures(ManifestMerger2.Invoker.Feature.NO_PLACEHOLDER_REPLACEMENT)
       .withFeatures(ManifestMerger2.Invoker.Feature.REMOVE_TOOLS_DECLARATIONS)
+      .withFeatures(ManifestMerger2.Invoker.Feature.USES_SDK_IN_MANIFEST_LENIENT_HANDLING)
       .apply {
         others.forEach { other ->
           addLibraryManifest(other.asTempFile())
@@ -35,6 +36,15 @@ class AndroidManifestMerger : Merger<AndroidManifest> {
       """.trimIndent()
     }
 
-    return AndroidManifest(mergeReport.getMergedDocument(MergingReport.MergedManifestKind.MERGED))
+    val document = mergeReport.getMergedDocument(MergingReport.MergedManifestKind.MERGED)
+    check(document != null) {
+      """
+        Failed to merge manifest. Expected merged document to be a string but it's null.
+
+        ${mergeReport.loggingRecords.joinToString("\n")}
+      """.trimIndent()
+    }
+
+    return AndroidManifest(document)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp-latest = "8.5.0"
-agp-tools = "31.5.0"
+agp-latest = "8.13.0"
+agp-tools = "31.13.2"
 detekt = "1.23.6"
 dokka = "1.9.20"
 kotlin = "1.9.24"


### PR DESCRIPTION
Use `USES_SDK_IN_MANIFEST_LENIENT_HANDLING` feature which allows `<uses-sdk>` elements.

`<uses-sdk>` is injected into the merged manifest and trips up AGP validation.